### PR TITLE
Run CI tests on Node.js 16, 18, and 20 using matrix strategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    
+    strategy:
+      matrix:
+        node-version: [16, 18, 20]
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -18,14 +20,14 @@ jobs:
       uses: actions/cache@v3
       with:
         path: node_modules
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}-${{ matrix.node-version }}
         restore-keys: |
           ${{ runner.os }}-node-
       
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: ${{ matrix.node-version }}
         
     - name: Install dependencies
       run: npm install


### PR DESCRIPTION
This PR updates the CI workflow to test across Node.js versions 16, 18, and 20 using a matrix build for improved compatibility.